### PR TITLE
Adding patch for cadence ethernet driver to prevent crashes

### DIFF
--- a/meta-sulfur/recipes-kernel/linux/linux-yocto-4.12/0043-net-ethernet-cadence-fix-sleep-in-atomic-bug.patch
+++ b/meta-sulfur/recipes-kernel/linux/linux-yocto-4.12/0043-net-ethernet-cadence-fix-sleep-in-atomic-bug.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/net/ethernet/cadence/macb.c b/drivers/net/ethernet/cadence/macb.c
+index 91f7492..bf773ac 100644
+--- a/drivers/net/ethernet/cadence/macb.c
++++ b/drivers/net/ethernet/cadence/macb.c
+@@ -574,7 +574,7 @@ static int macb_halt_tx(struct macb *bp)
+ 		if (!(status & MACB_BIT(TGO)))
+ 			return 0;
+
+-		usleep_range(10, 250);
++		udelay(250);
+ 	} while (time_before(halt_time, timeout));
+
+ 	return -ETIMEDOUT;

--- a/meta-sulfur/recipes-kernel/linux/linux-yocto-4.12/sulfur.scc
+++ b/meta-sulfur/recipes-kernel/linux/linux-yocto-4.12/sulfur.scc
@@ -38,3 +38,4 @@ patch 0039-ARM-dt-Add-devicetree-files-for-Rhodium-Rev0-SDR.patch
 patch 0042-ARM-dt-Add-devicetree-files-for-NI-Projects-Phosphor.patch
 patch 0001-ARM-dt-Refactor-the-magnesium-daughterboards-using-d.patch
 patch 0002-ARM-dt-Add-Sulfur-Phosphorus-Rev6-boards.patch
+patch 0043-net-ethernet-cadence-fix-sleep-in-atomic-bug.patch


### PR DESCRIPTION
The N310 eth0 cadence driver occasionally causes the system to crash while transferring large files or installing cross compiled things via scp/sshfs - the stack trace from the serial console and some googling lead me here https://lore.kernel.org/patchwork/patch/980132/ which patches the halt while atomic issue I was seeing.

I've pulled in the patch and backported it to work with the driver in kernel 4.12  (minor changes) and confirmed this patch resolves the ethernet troubles I was having. 