### PR TITLE
contrib: Fix create_packages conditional syntax

### DIFF
--- a/contrib/create_packages.sh
+++ b/contrib/create_packages.sh
@@ -150,7 +150,7 @@ if [ ! -z $_sdk_pkg_name ]; then
 	fi
 fi
 
-if [! -d "$_deploy_dir/sources" ]; then
+if [ ! -d "$_deploy_dir/sources" ]; then
 	echo "WARNING: Could not find Sources!"
 else
 	echo "Found Sources in: $_deploy_dir/sources. Files:"


### PR DESCRIPTION
A missing space causes "bash: [!: command not found..." and script attempts to zip sources unconditionally.